### PR TITLE
[#3] Setup app secret in AWS SSM

### DIFF
--- a/elixir-fargate/main.tf
+++ b/elixir-fargate/main.tf
@@ -75,6 +75,20 @@ module "ecr" {
   owner     = var.owner
 }
 
+module "ssm" {
+  source = "./modules/ssm"
+
+  namespace         = var.app_name
+  environment       = var.environment
+  
+  secret_key_base   = var.secret_key_base
+  
+  rds_username      = var.rds_username
+  rds_password      = var.rds_password
+  rds_endpoint      = module.db.db_instance_endpoint
+  rds_database_name = var.rds_database_name
+}
+
 module "ecs" {
   source = ".././modules/ecs"
 
@@ -88,10 +102,10 @@ module "ecs" {
   alb_target_group_arn          = module.alb.alb_target_group_arn
   aws_ecr_repository_url        = module.ecr.repository_url
   aws_cloudwatch_log_group_name = module.log.aws_cloudwatch_log_group_name
-  aws_ssm_parameter_arn         = var.aws_ssm_parameter_arn
   desired_count                 = var.ecs_desired_count
   cpu                           = var.ecs_cpu
   memory                        = var.ecs_memory
   owner                         = var.owner
   environment                   = var.environment
+  aws_parameter_store           = module.ssm.parameter_store
 }

--- a/elixir-fargate/modules/ssm/main.tf
+++ b/elixir-fargate/modules/ssm/main.tf
@@ -1,0 +1,15 @@
+locals {
+  parameter_store_namespace = "/${var.namespace}/${var.environment}"
+}
+
+resource "aws_ssm_parameter" "secret_key_base" {
+  name  = "${local.parameter_store_namespace}/SECRET_KEY_BASE"
+  type  = "String"
+  value = var.secret_key_base
+}
+
+resource "aws_ssm_parameter" "database_url" {
+  name  = "${local.parameter_store_namespace}/DATABASE_URL"
+  type  = "String"
+  value = "postgresql://${var.rds_username}:${var.rds_password}@${var.rds_endpoint}/${var.rds_database_name}"
+}

--- a/elixir-fargate/modules/ssm/outputs.tf
+++ b/elixir-fargate/modules/ssm/outputs.tf
@@ -1,0 +1,6 @@
+output "parameter_store" {
+  value = {
+    secret_base_ssm_arn   = aws_ssm_parameter.secret_key_base.arn
+    database_url_ssm_arn  = aws_ssm_parameter.database_url.arn
+  }
+}

--- a/elixir-fargate/modules/ssm/variables.tf
+++ b/elixir-fargate/modules/ssm/variables.tf
@@ -1,0 +1,26 @@
+variable "namespace" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "secret_key_base" {
+  type = string
+}
+variable "rds_username" {
+  type = string
+}
+
+variable "rds_password" {
+  type = string
+}
+
+variable "rds_endpoint" {
+  type = string
+}
+
+variable "rds_database_name" {
+  type = string
+}

--- a/elixir-fargate/outputs.tf
+++ b/elixir-fargate/outputs.tf
@@ -1,4 +1,0 @@
-output "vpc_id" {
-  description = "VPC ID"
-  value       = "module.vpc.vpc_id"
-}

--- a/elixir-fargate/task_definitions/service.json.tpl
+++ b/elixir-fargate/task_definitions/service.json.tpl
@@ -32,11 +32,11 @@
     "secrets": [
       {
         "name": "DATABASE_URL",
-        "valueFrom": "${aws_parameter_store}/DATABASE_URL"
+        "valueFrom": "${database_url_ssm_arn}"
       },
       {
         "name": "SECRET_KEY_BASE",
-        "valueFrom": "${aws_parameter_store}/SECRET_KEY_BASE"
+        "valueFrom": "${secret_base_ssm_arn}"
       }
     ]
   }

--- a/elixir-fargate/variables.tf
+++ b/elixir-fargate/variables.tf
@@ -11,7 +11,7 @@ variable "owner" {
 }
 
 variable "environment" {
-  default = "staging"
+  description = "Application environment"
 }
 
 variable "rds_instance_type" {
@@ -20,7 +20,6 @@ variable "rds_instance_type" {
 
 variable "rds_database_name" {
   description = "RDS database name"
-  default = "SampleElixirAppStagingDb"
 }
 
 variable "rds_username" {
@@ -43,6 +42,6 @@ variable "ecs_desired_count" {
   default = 2
 }
 
-variable "aws_ssm_parameter_arn" {
-  description = "Amazon SSM parameter store"
+variable "secret_key_base" {
+  description = "Generate secret key base with mix phx.gen.secret"
 }

--- a/modules/db/outputs.tf
+++ b/modules/db/outputs.tf
@@ -1,0 +1,3 @@
+output "db_instance_endpoint" {
+  value = module.db.db_instance_endpoint
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,16 +1,15 @@
 data "template_file" "main" {
   template = var.task_definition_template
 
-  vars = {
+  vars = merge({
     namespace                     = var.namespace
     region                        = var.region
     tag                           = "latest"
     app_host                      = var.app_host
     app_port                      = var.app_port
     aws_ecr_repository            = var.aws_ecr_repository_url
-    aws_parameter_store           = var.aws_ssm_parameter_arn
     aws_cloudwatch_log_group_name = var.aws_cloudwatch_log_group_name
-  }
+  }, var.aws_parameter_store)
 }
 
 data "aws_iam_policy_document" "ecs_task_execution_role" {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -23,10 +23,6 @@ variable "aws_ecr_repository_url" {
   description = "Amazon ECR repository URL"
 }
 
-variable "aws_ssm_parameter_arn" {
-  description = "Amazon SSM Parameter Store"
-}
-
 variable "subnets" {
   description = "Subnet where ECS placed"
   type        = list(any)
@@ -63,4 +59,9 @@ variable "owner" {
 
 variable "environment" {
   type = string
+}
+
+variable "aws_parameter_store" {
+  type = map
+  default = {}
 }


### PR DESCRIPTION
## Description
Deploy application from `elixir-template` with `elixir-fargate` preset
1. Run `terraform apply` from `elixir-fargate` directory
2. Push application image to ECR
3. Application is deployed

This is an improvement from the previous PR. Now, we can deploy application without any extra configuration from AWS.

## Proof of work
Application is deployed at http://sample-phoenix-app-alb-1726641027.ap-southeast-1.elb.amazonaws.com/
![image](https://user-images.githubusercontent.com/14077479/143392710-1c506c12-f32b-47d3-83a3-2f830954ae95.png)
